### PR TITLE
fcntl.hとsys/stat.h

### DIFF
--- a/chap3/3.4/3_4_2_posix_semaphore.c
+++ b/chap3/3.4/3_4_2_posix_semaphore.c
@@ -1,6 +1,4 @@
 #include <pthread.h> // <1>
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <semaphore.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
'fcntl.h'と'sys/stat.h'はなくても手元の環境では動きます。他のサンプルコードではインクルードは必要最小限にされているようですが…？