### PR TITLE
Update 3_6_2_barrier_pthreads.c

### DIFF
--- a/chap3/3.6/3_6_2_barrier_pthreads.c
+++ b/chap3/3.6/3_6_2_barrier_pthreads.c
@@ -10,7 +10,7 @@ void barrier(volatile int *cnt, int max) {
         perror("pthread_mutex_lock"); exit(-1);
     }
 
-    *cnt++; // <1>
+    (*cnt)++; // <1>
 
     if (*cnt == max) { // <2>
         // 全プロセスが揃ったので通知 <3>


### PR DESCRIPTION
*と++の優先順位は同じですが右結合だそうで、()がないとインクリメントされませんでした。