### PR TITLE
第1刷 p.67 のソースコードのtypo修正

### DIFF
--- a/chap3/3.3/3_3_1_spinlock_1.c
+++ b/chap3/3.3/3_3_1_spinlock_1.c
@@ -1,7 +1,7 @@
 #include "../3.2/3_2_2_tas.c"
 
 void spinlock_acquire(bool *lock) {
-    while (test_and_set(lock)); // <1>
+    while (!test_and_set(lock)); // <1>
 }
 
 void spinlock_release(bool *lock) {

--- a/errata.md
+++ b/errata.md
@@ -79,6 +79,7 @@ https://oreilly-japan.github.io/conc_ytakano/barrier.html
 | 3章。P.64。下段の1行目。 | MUTtual EXecution | MUTual EXclusion |
 | 3章。P.65。❷の3行目。 | 代入してして | 代入して |
 | 3章。P.67。3.3.1の1行目。 | 繰り返していていたが、 | 繰り返していたが、 |
+| 3章。P.67。ソースコードの上から2行目 | `while (test_and_set(lock)); // <1>` | `while (!test_and_set(lock)); // <1>` |
 | 3章。P.73。ソースコード。main関数から4行目。 | `sem_open("/mysemaphore", O_CREAT, 0066, 3);` | `sem_open("/mysemaphore", O_CREAT, 0660, 3);` |
 | 3章。P.74。❼の2行目 | 第3引数の0066は | 第3引数の0660 は |
 | 3章。P.78。1つ目のソースコードの上から1行目。| `volatile int num = 10;` | `volatile int num = 0;` |


### PR DESCRIPTION
第1刷 p.67 のソースコードのtypo修正です。

    誤 : `while (test_and_set(lock)); // <1>`
    正 : `while (!test_and_set(lock)); // <1>`

